### PR TITLE
Develop

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -20,7 +20,7 @@ Depending on the IDE, you may need to wait for dependencies to download and thin
 
 To perform a project build, run the `mvn package` command. 
 
-- **IntelliJ** In the Maven tab, double click the `package` option under Lifecycle.
+- **IntelliJ** In the Maven tab, double-click the `package` option under Lifecycle.
 - **Eclipse** Right click `pom.xml` -> `Run as...` -> Choose `Maven build...` -> Type `package` in the Goals textfield -> Run
 
 The build files will appear in folder `target/package/` and contains the following:
@@ -41,7 +41,7 @@ Maven will also insert these values into `Settings.fxml` during the build.
 There are two ways to run this application from your IDE
 
 1. **From in IDE** Right click on file and run `src/main/java/io.mattw.youtube.commentsuite/CommentSuite.java`
-2. **From package** Double click the jar at `target/package/youtube-comment-suite-#.#.#.jar` 
+2. **From package** Double-click the jar at `target/package/youtube-comment-suite-#.#.#.jar` 
 
 *Note: My YouTube API key provided in the application is not restricted at all given it isn't a website.
 Access should work for all local development. Please do not abuse it such that it uses up the daily quota.*

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ YouTube creators and more.
 * Display stats about videos: publishes per week, most popular, most disliked, most commented, and disabled.
 * Display stats about comments: posts per week, most active posters, most popular posters.
 * Option to save thumbnails and profiles for archival and offline viewing.
-* Sign into multiple YouTube accounts and choose which to reply with.
+* Sign in to multiple YouTube accounts and choose which to reply with.
 * View video context when selecting a comment.
 
 ## Install

--- a/README.md
+++ b/README.md
@@ -52,17 +52,17 @@ When extracting the latest release zip, be sure to include the `lib` folder alon
 
 Simply extracting all zip contents to a folder will do this.
 
-### Getting Started
+## Getting Started
 
 Want to know more about how to use this
 program? [Check out the Wiki!](https://github.com/mattwright324/youtube-comment-suite/wiki/Overview-of-the-interface)
 
-### Building
+## Building
 
 Refer to [BUILD.md](https://github.com/mattwright324/youtube-comment-suite/blob/master/BUILD.md)
 for instructions on how to build and run `youtube-comment-suite` from source.
 
-### Contributing
+## Contributing
 
 Contributions are welcome, refer
 to [CONTRIBUTING.md](https://github.com/mattwright324/youtube-comment-suite/blob/master/CONTRIBUTING.md)

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.mattw.youtube</groupId>
     <artifactId>youtube-comment-suite</artifactId>
-    <version>1.4.6</version>
+    <version>1.4.7</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -137,6 +137,11 @@
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
+            <artifactId>commons-csv</artifactId>
+            <version>1.9.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <version>3.11</version>
         </dependency>

--- a/src/main/java/io/mattw/youtube/commentsuite/CommentSuite.java
+++ b/src/main/java/io/mattw/youtube/commentsuite/CommentSuite.java
@@ -18,8 +18,10 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.security.GeneralSecurityException;
 import java.sql.SQLException;
+import java.util.Properties;
 
 /**
  * Application Window
@@ -36,6 +38,7 @@ public class CommentSuite extends Application {
     private static CommentDatabase database;
     private static YouTube youTube;
     private static OAuth2Manager oauth2Manager;
+    private static final Properties properties = new Properties();
 
     public static void main(String[] args) {
         logger.debug("Starting Application");
@@ -63,6 +66,9 @@ public class CommentSuite extends Application {
                     .build();
             database = new CommentDatabase("commentsuite.sqlite3");
             oauth2Manager = new OAuth2Manager();
+            try (InputStream is = CommentSuite.class.getResourceAsStream("/application.properties")) {
+                properties.load(is);
+            }
 
             final Parent parent = FXMLLoader.load(getClass().getResource("/io/mattw/youtube/commentsuite/fxml/Main.fxml"));
 
@@ -123,6 +129,10 @@ public class CommentSuite extends Application {
 
     public static String getYouTubeApiKey() {
         return getConfig().getDataObject().getApiKeyOrDefault();
+    }
+
+    public static Properties getProperties() {
+        return properties;
     }
 
 }

--- a/src/main/java/io/mattw/youtube/commentsuite/CommentSuite.java
+++ b/src/main/java/io/mattw/youtube/commentsuite/CommentSuite.java
@@ -45,7 +45,7 @@ public class CommentSuite extends Application {
 
         /*
          * Setting this system property is a fix for the JavaFX Webview behaving improperly.
-         * The 'Tap Yes' authentication when signing in from {@link mattw.youtube.commentsuite.fxml.Settings)
+         * The 'Tap Yes' authentication when signing in from {@link io.mattw.youtube.commentsuite.fxml.Settings}
          * would do nothing and the icon would flicker when not set, requiring the user to use SMS
          * authentication instead.
          */

--- a/src/main/java/io/mattw/youtube/commentsuite/db/CommentDatabase.java
+++ b/src/main/java/io/mattw/youtube/commentsuite/db/CommentDatabase.java
@@ -199,7 +199,7 @@ public class CommentDatabase implements Closeable {
     }
 
     /**
-     * Returns all of the comments associated with a comment parentId.
+     * Returns all the comments associated with a comment parentId.
      */
     public List<YouTubeComment> getCommentTree(String parentId, boolean includeModeration) throws SQLException {
         try (PreparedStatement ps = sqlite.prepareStatement(GET_COMMENT_TREE.toString())) {

--- a/src/main/java/io/mattw/youtube/commentsuite/db/CommentQuery.java
+++ b/src/main/java/io/mattw/youtube/commentsuite/db/CommentQuery.java
@@ -371,6 +371,19 @@ public class CommentQuery implements Serializable, Exportable {
         return this;
     }
 
+    public CommentQuery duplicate() {
+        return database.commentQuery()
+                .setGroup(this.getGroup())
+                .setGroupItem(this.getGroupItem())
+                .setCommentsType(this.getCommentsType())
+                .setVideos(this.getVideos())
+                .setNameLike(this.getNameLike())
+                .setOrder(this.getOrder())
+                .setTextLike(this.getTextLike())
+                .setDateFrom(this.getDateFrom())
+                .setDateTo(this.getDateTo());
+    }
+
     @Override
     public void prepForExport() {
         if(group != null) {

--- a/src/main/java/io/mattw/youtube/commentsuite/db/CommentQuery.java
+++ b/src/main/java/io/mattw/youtube/commentsuite/db/CommentQuery.java
@@ -233,22 +233,18 @@ public class CommentQuery implements Serializable, Exportable {
      * <p>
      * {@link io.mattw.youtube.commentsuite.fxml.SCExportModal}
      */
-    public Set<String> getUniqueVideoIds() throws SQLException {
+    public Set<YouTubeVideo> getUniqueVideos() throws SQLException {
         Objects.requireNonNull(group);
 
-        Set<String> items = new HashSet<>();
+        Set<YouTubeVideo> items = new HashSet<>();
 
         if (videos.isPresent()) {
-            items.addAll(videos.get()
-                    .stream()
-                    .filter(Objects::nonNull)
-                    .map(YouTubeVideo::getId)
-                    .collect(Collectors.toList()));
+            items.addAll(videos.get());
         } else {
             if (groupItem.isPresent()) {
-                items.addAll(database.videos().idsByGroupItem(groupItem.get()));
+                items.addAll(database.videos().byGroupItem(groupItem.get()));
             } else {
-                items.addAll(database.videos().idsByGroup(group));
+                items.addAll(database.videos().byGroup(group));
             }
         }
 
@@ -354,6 +350,11 @@ public class CommentQuery implements Serializable, Exportable {
         return this;
     }
 
+    protected CommentQuery setTotalResults(long totalResults) {
+        this.totalResults = totalResults;
+        return this;
+    }
+
     public long getTotalResults() {
         return totalResults;
     }
@@ -381,7 +382,8 @@ public class CommentQuery implements Serializable, Exportable {
                 .setOrder(this.getOrder())
                 .setTextLike(this.getTextLike())
                 .setDateFrom(this.getDateFrom())
-                .setDateTo(this.getDateTo());
+                .setDateTo(this.getDateTo())
+                .setTotalResults(this.getTotalResults());
     }
 
     @Override

--- a/src/main/java/io/mattw/youtube/commentsuite/db/ModeratedCommentsTable.java
+++ b/src/main/java/io/mattw/youtube/commentsuite/db/ModeratedCommentsTable.java
@@ -7,7 +7,6 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 
-import static io.mattw.youtube.commentsuite.db.SQLLoader.INSERT_OR_COMMENTS;
 import static io.mattw.youtube.commentsuite.db.SQLLoader.INSERT_OR_MODERATED_COMMENTS;
 
 public class ModeratedCommentsTable extends TableHelper<YouTubeComment> {

--- a/src/main/java/io/mattw/youtube/commentsuite/db/NamedParameterStatement.java
+++ b/src/main/java/io/mattw/youtube/commentsuite/db/NamedParameterStatement.java
@@ -270,7 +270,7 @@ public class NamedParameterStatement implements AutoCloseable {
 
 
     /**
-     * Executes all of the batched statements.
+     * Executes all the batched statements.
      * <p>
      * See {@link Statement#executeBatch()} for details.
      *

--- a/src/main/java/io/mattw/youtube/commentsuite/db/VideosTable.java
+++ b/src/main/java/io/mattw/youtube/commentsuite/db/VideosTable.java
@@ -152,6 +152,10 @@ public class VideosTable extends TableHelper<YouTubeVideo> {
         }
     }
 
+    public List<YouTubeVideo> byGroup(Group group) throws SQLException {
+        return byGroupCriteria(group, "", "publish_date DESC", Integer.MAX_VALUE);
+    }
+
     public List<YouTubeVideo> byGroupCriteria(Group group, String keyword, String order, int limit) throws SQLException {
         try (PreparedStatement ps = preparedStatement(GET_VIDEOS_BY_CRITERIA_GROUP.toString().replace(":order", order))) {
             ps.setString(1, group.getGroupId());
@@ -161,6 +165,10 @@ public class VideosTable extends TableHelper<YouTubeVideo> {
 
             return toList(ps);
         }
+    }
+
+    public List<YouTubeVideo> byGroupItem(GroupItem groupItem) throws SQLException {
+        return byGroupItemCriteria(groupItem, "", "publish_date DESC", Integer.MAX_VALUE);
     }
 
     public List<YouTubeVideo> byGroupItemCriteria(GroupItem groupItem, String keyword, String order, int limit) throws SQLException {

--- a/src/main/java/io/mattw/youtube/commentsuite/db/VideosTable.java
+++ b/src/main/java/io/mattw/youtube/commentsuite/db/VideosTable.java
@@ -21,7 +21,7 @@ public class VideosTable extends TableHelper<YouTubeVideo> {
                 .setChannelId(resultSet.getString("channel_id"))
                 .setDescription(resultSet.getString("video_desc"))
                 .setPublished(resultSet.getLong("publish_date"))
-                .setRefreshedOn(resultSet.getLong("publish_date"))
+                .setRefreshedOn(resultSet.getLong("grab_date"))
                 .setComments(resultSet.getLong("total_comments"))
                 .setLikes(resultSet.getLong("total_likes"))
                 .setDislikes(resultSet.getLong("total_dislikes"))

--- a/src/main/java/io/mattw/youtube/commentsuite/db/YouTubeComment.java
+++ b/src/main/java/io/mattw/youtube/commentsuite/db/YouTubeComment.java
@@ -47,11 +47,11 @@ public class YouTubeComment implements Linkable, Exportable {
         commentDate = publishedDateTime.toString();
     }
 
-    public static final String[] CSV_HEADER = {"id", "parentId", "videoId", "channelId", "channelName", "channelThumb", "commentDate", "commentText", "likes", "replyCount", "tags"};
+    public static final String[] CSV_HEADER = {"id", "parentId", "videoId", "channelId", "channelName", "channelThumb", "commentDate", "commentText", "likes", "isReply", "replyCount", "tags"};
 
     public Object[] getCsvRow() {
-        return new Object[]{id, parentId, videoId, channelId, author.getTitle(), author.getThumbUrl(), commentDate, commentText.replaceAll("[\r\n]*", ""),
-                likes, replyCount, tags == null ? "" : tags.toString()
+        return new Object[]{id, parentId, videoId, author.getId(), author.getTitle(), author.getThumbUrl(), commentDate, commentText.replaceAll("[\r\n]*", ""),
+                likes, isReply, replyCount == -1 ? "" : replyCount, tags == null ? "" : tags.toString()
         };
     }
 

--- a/src/main/java/io/mattw/youtube/commentsuite/db/YouTubeComment.java
+++ b/src/main/java/io/mattw/youtube/commentsuite/db/YouTubeComment.java
@@ -1,6 +1,5 @@
 package io.mattw.youtube.commentsuite.db;
 
-import com.google.api.client.util.ArrayMap;
 import com.google.api.client.util.DateTime;
 import com.google.api.services.youtube.model.Comment;
 import com.google.api.services.youtube.model.CommentSnippet;
@@ -19,7 +18,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
-import static org.apache.commons.lang3.StringUtils.*;
+import static org.apache.commons.lang3.StringUtils.isAnyBlank;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 public class YouTubeComment implements Linkable, Exportable {
 
@@ -41,15 +41,22 @@ public class YouTubeComment implements Linkable, Exportable {
 
     // Field(s) used just for export to make things pretty.
     private YouTubeChannel author;
-    private List<YouTubeComment> replies;
-
-    public YouTubeChannel getChannel() {
-        return CommentSuite.getDatabase().channels().getOrNull(channelId);
-    }
 
     @Override
     public void prepForExport() {
         commentDate = publishedDateTime.toString();
+    }
+
+    public static final String[] CSV_HEADER = {"id", "parentId", "videoId", "channelId", "channelName", "commentDate", "commentText", "likes", "replyCount", "tags"};
+
+    public Object[] getCsvRow() {
+        return new Object[]{id, parentId, videoId, channelId, author.getTitle(), commentDate, commentText.replaceAll("[\r\n]*", ""),
+                likes, replyCount, tags == null ? "" : tags.toString()
+        };
+    }
+
+    public YouTubeChannel getChannel() {
+        return CommentSuite.getDatabase().channels().getOrNull(channelId);
     }
 
     public String getId() {
@@ -179,24 +186,12 @@ public class YouTubeComment implements Linkable, Exportable {
         return author;
     }
 
-    public List<YouTubeComment> getReplies() {
-        return replies;
-    }
-
     /**
      * Overwrite channelId as null when set because it will be on the channel object for export.
      */
     public YouTubeComment setAuthor(YouTubeChannel author) {
         this.channelId = null;
         this.author = author;
-        return this;
-    }
-
-    /**
-     * List of comment replies to this parent comment.
-     */
-    public YouTubeComment setReplies(List<YouTubeComment> replies) {
-        this.replies = replies;
         return this;
     }
 
@@ -227,7 +222,7 @@ public class YouTubeComment implements Linkable, Exportable {
      */
     public String getCleanText(boolean withNewLines) {
         return StringEscapeUtils.unescapeHtml4(commentText)
-                .replace("<br />", withNewLines ? "\r\n" : " ")
+                .replaceAll("<br[ /]*>", withNewLines ? "\r\n" : " ")
                 .replaceAll("[̀-ͯ᪰-᫿᷀-᷿⃐-⃿︠-︯]", "");
     }
 

--- a/src/main/java/io/mattw/youtube/commentsuite/db/YouTubeComment.java
+++ b/src/main/java/io/mattw/youtube/commentsuite/db/YouTubeComment.java
@@ -47,10 +47,10 @@ public class YouTubeComment implements Linkable, Exportable {
         commentDate = publishedDateTime.toString();
     }
 
-    public static final String[] CSV_HEADER = {"id", "parentId", "videoId", "channelId", "channelName", "commentDate", "commentText", "likes", "replyCount", "tags"};
+    public static final String[] CSV_HEADER = {"id", "parentId", "videoId", "channelId", "channelName", "channelThumb", "commentDate", "commentText", "likes", "replyCount", "tags"};
 
     public Object[] getCsvRow() {
-        return new Object[]{id, parentId, videoId, channelId, author.getTitle(), commentDate, commentText.replaceAll("[\r\n]*", ""),
+        return new Object[]{id, parentId, videoId, channelId, author.getTitle(), author.getThumbUrl(), commentDate, commentText.replaceAll("[\r\n]*", ""),
                 likes, replyCount, tags == null ? "" : tags.toString()
         };
     }

--- a/src/main/java/io/mattw/youtube/commentsuite/db/YouTubeVideo.java
+++ b/src/main/java/io/mattw/youtube/commentsuite/db/YouTubeVideo.java
@@ -39,8 +39,8 @@ public class YouTubeVideo implements Linkable, HasImage, Exportable {
     public static final String[] CSV_HEADER = {"id", "channelId", "title", "thumbUrl", "description", "publishDate", "viewCount", "comments", "likes", "dislikes", "responseCode"};
 
     public Object[] getCsvRow() {
-        return new Object[] {id, channelId, title, thumbUrl, description.replaceAll("([\r]?\n)+", "<br>"), publishDate,
-                viewCount, comments, likes, dislikes, responseCode};
+        return new Object[] {id, channelId, title, thumbUrl, description.replaceAll("([\r]?\n)+", "<br>"),
+                publishDate, viewCount, comments, likes, dislikes, responseCode};
     }
 
     @Override

--- a/src/main/java/io/mattw/youtube/commentsuite/db/YouTubeVideo.java
+++ b/src/main/java/io/mattw/youtube/commentsuite/db/YouTubeVideo.java
@@ -7,8 +7,11 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.math.BigInteger;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.Callable;
 import java.util.stream.Stream;
 
 import static org.apache.commons.lang3.StringUtils.isAnyBlank;
@@ -36,6 +39,13 @@ public class YouTubeVideo implements Linkable, HasImage, Exportable {
 
     // Field(s) used just for export
     private YouTubeChannel author;
+
+    public static final String[] CSV_HEADER = {"id", "channelId", "title", "thumbUrl", "description", "publishDate", "viewCount", "comments", "likes", "dislikes", "responseCode"};
+
+    public Object[] getCsvRow() {
+        return new Object[] {id, channelId, title, thumbUrl, description.replaceAll("([\r]?\n)+", "<br>"), publishDate,
+                viewCount, comments, likes, dislikes, responseCode};
+    }
 
     @Override
     public String getId() {
@@ -215,7 +225,7 @@ public class YouTubeVideo implements Linkable, HasImage, Exportable {
                 .map(ThumbnailDetails::getDefault)
                 .map(Thumbnail::getUrl)
                 .orElse(null);
-        final String description = snippet.map(VideoSnippet::getTitle).orElse(null);
+        final String description = snippet.map(VideoSnippet::getDescription).orElse(null);
         final long published = snippet
                 .map(VideoSnippet::getPublishedAt)
                 .map(DateTime::getValue)

--- a/src/main/java/io/mattw/youtube/commentsuite/db/YouTubeVideo.java
+++ b/src/main/java/io/mattw/youtube/commentsuite/db/YouTubeVideo.java
@@ -7,15 +7,11 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.math.BigInteger;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.concurrent.Callable;
 import java.util.stream.Stream;
 
 import static org.apache.commons.lang3.StringUtils.isAnyBlank;
-import static org.apache.commons.lang3.StringUtils.isBlank;
 
 public class YouTubeVideo implements Linkable, HasImage, Exportable {
 

--- a/src/main/java/io/mattw/youtube/commentsuite/fxml/ExportCommentFormat.java
+++ b/src/main/java/io/mattw/youtube/commentsuite/fxml/ExportCommentFormat.java
@@ -1,0 +1,6 @@
+package io.mattw.youtube.commentsuite.fxml;
+
+public enum ExportCommentFormat {
+    PER_VIDEO,
+    SINGLE
+}

--- a/src/main/java/io/mattw/youtube/commentsuite/fxml/ExportFormat.java
+++ b/src/main/java/io/mattw/youtube/commentsuite/fxml/ExportFormat.java
@@ -1,0 +1,16 @@
+package io.mattw.youtube.commentsuite.fxml;
+
+public enum ExportFormat {
+    JSON("json"),
+    CSV("csv");
+
+    private final String extension;
+
+    ExportFormat(String extension) {
+        this.extension = extension;
+    }
+
+    public String getExtension() {
+        return extension;
+    }
+}

--- a/src/main/java/io/mattw/youtube/commentsuite/fxml/MGMVAddItemModal.java
+++ b/src/main/java/io/mattw/youtube/commentsuite/fxml/MGMVAddItemModal.java
@@ -27,7 +27,7 @@ import static javafx.application.Platform.runLater;
  * This modal allows the user to add a GroupItem to the Group of the ManageGroupsManager with a YouTube link.
  * The YouTube link can be any of a video, channel, or playlist and should match the example formats to be accepted.
  *
- * @see GroupItem#GroupItem(String)
+ * @see GroupItem
  * @see ManageGroupsManager
  */
 public class MGMVAddItemModal extends VBox implements Cleanable {

--- a/src/main/java/io/mattw/youtube/commentsuite/fxml/MGMVGroupItemView.java
+++ b/src/main/java/io/mattw/youtube/commentsuite/fxml/MGMVGroupItemView.java
@@ -36,26 +36,24 @@ public class MGMVGroupItemView extends HBox {
         try {
             loader.load();
 
-            if (ConfigData.FAST_GROUP_ADD_THUMB_PLACEHOLDER.equals(groupItem.getThumbUrl())) {
-                icon.setManaged(false);
-                icon.setVisible(false);
-            } else {
-                icon.setImage(ImageCache.findOrGetImage(groupItem.getId(), groupItem.getThumbUrl()));
-                icon.setManaged(true);
-                icon.setVisible(true);
-            }
-
             title.setText(groupItem.getDisplayName());
             author.setText(groupItem.getChannelTitle());
             type.setText(groupItem.getType().getDisplay());
 
-            icon.setCursor(Cursor.HAND);
-            icon.setOnMouseClicked(me -> browserUtil.open(groupItem.toYouTubeLink()));
+            if (ConfigData.FAST_GROUP_ADD_THUMB_PLACEHOLDER.equals(groupItem.getThumbUrl())) {
+                icon.setManaged(false);
+                icon.setVisible(false);
+            } else {
+                icon.setManaged(true);
+                icon.setVisible(true);
+                icon.setCursor(Cursor.HAND);
+                icon.setOnMouseClicked(me -> browserUtil.open(groupItem.toYouTubeLink()));
 
-            new Thread(() -> {
-                Image image = ImageCache.findOrGetImage(groupItem.getId(), groupItem.getThumbUrl());
-                runLater(() -> icon.setImage(image));
-            }).start();
+                new Thread(() -> {
+                    Image image = ImageCache.findOrGetImage(groupItem.getId(), groupItem.getThumbUrl());
+                    runLater(() -> icon.setImage(image));
+                }).start();
+            }
 
         } catch (IOException e) {
             e.printStackTrace();

--- a/src/main/java/io/mattw/youtube/commentsuite/fxml/MGMVStatItem.java
+++ b/src/main/java/io/mattw/youtube/commentsuite/fxml/MGMVStatItem.java
@@ -16,7 +16,6 @@ import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.stream.Stream;
 
 import static javafx.application.Platform.runLater;

--- a/src/main/java/io/mattw/youtube/commentsuite/fxml/ManageGroups.java
+++ b/src/main/java/io/mattw/youtube/commentsuite/fxml/ManageGroups.java
@@ -5,7 +5,6 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.eventbus.Subscribe;
 import io.mattw.youtube.commentsuite.CommentSuite;
 import io.mattw.youtube.commentsuite.ImageLoader;
-import io.mattw.youtube.commentsuite.db.CommentDatabase;
 import io.mattw.youtube.commentsuite.db.Group;
 import io.mattw.youtube.commentsuite.events.GroupAddEvent;
 import io.mattw.youtube.commentsuite.events.GroupDeleteEvent;

--- a/src/main/java/io/mattw/youtube/commentsuite/fxml/SCExportModal.java
+++ b/src/main/java/io/mattw/youtube/commentsuite/fxml/SCExportModal.java
@@ -136,8 +136,7 @@ public class SCExportModal extends VBox implements Cleanable, ImageCache {
 
             new Thread(() -> {
                 while (exportProducer.shouldKeepAlive()) {
-                    final double progress = exportProducer.getTotalProcessed().get() / (exportProducer.getTotalAccepted().get() * 1d);
-                    runLater(() -> exportProgress.setProgress(progress));
+                    updateProgress();
 
                     Threads.awaitMillis(100);
                 }
@@ -148,6 +147,7 @@ public class SCExportModal extends VBox implements Cleanable, ImageCache {
             }).start();
 
             exportProducer.getExecutorGroup().await();
+            updateProgress();
             exportProducer.onCompletion();
         } catch (SQLException | InterruptedException e) {
             logger.error(e);
@@ -159,6 +159,11 @@ public class SCExportModal extends VBox implements Cleanable, ImageCache {
                 btnClose.setDisable(false);
             });
         }
+    }
+
+    private void updateProgress() {
+        final double progress = exportProducer.getTotalProcessed().get() / (exportProducer.getTotalAccepted().get() * 1d);
+        runLater(() -> exportProgress.setProgress(progress));
     }
 
     private void createSearchSettingsFile(final File exportFolder, final CommentQuery query) {

--- a/src/main/java/io/mattw/youtube/commentsuite/fxml/SCExportModal.java
+++ b/src/main/java/io/mattw/youtube/commentsuite/fxml/SCExportModal.java
@@ -124,25 +124,14 @@ public class SCExportModal extends VBox implements Cleanable, ImageCache {
             btnClose.setDisable(true);
         });
 
-        // Duplicate a new query object because it isn't threadsafe.
-        // ExecutorGroup should make export faster
-        final CommentQuery localQuery = database.commentQuery()
-                .setGroup(commentQuery.getGroup())
-                .setGroupItem(commentQuery.getGroupItem())
-                .setCommentsType(commentQuery.getCommentsType())
-                .setVideos(commentQuery.getVideos())
-                .setNameLike(commentQuery.getNameLike())
-                .setOrder(commentQuery.getOrder())
-                .setTextLike(commentQuery.getTextLike())
-                .setDateFrom(commentQuery.getDateFrom())
-                .setDateTo(commentQuery.getDateTo());
-
         try {
-            exportProducer = new SCExportProducer(localQuery, radioCondensed.isSelected());
-            createSearchSettingsFile(exportProducer.getThisExportFolder(), localQuery);
+            final CommentQuery duplicateQuery = commentQuery.duplicate();
+
+            exportProducer = new SCExportProducer(commentQuery, radioCondensed.isSelected());
+            createSearchSettingsFile(exportProducer.getThisExportFolder(), duplicateQuery);
 
             exportProducer.setMessageFunc(this::onMessage);
-            exportProducer.accept(localQuery.getUniqueVideoIds());
+            exportProducer.accept(duplicateQuery.getUniqueVideoIds());
             exportProducer.startProducing();
 
             new Thread(() -> {

--- a/src/main/java/io/mattw/youtube/commentsuite/fxml/SCExportModal.java
+++ b/src/main/java/io/mattw/youtube/commentsuite/fxml/SCExportModal.java
@@ -297,7 +297,7 @@ public class SCExportModal extends VBox implements Cleanable, ImageCache {
                         commentsProcessed++;
 
                         final long total = query.getTotalResults();
-                        if (total < 25000 || commentsProcessed % 100 == 0) {
+                        if (total < 25000 && commentsProcessed % 10 == 0 || commentsProcessed % 100 == 0) {
                             updateProgressSingle();
                         }
                     }

--- a/src/main/java/io/mattw/youtube/commentsuite/fxml/SCExportModal.java
+++ b/src/main/java/io/mattw/youtube/commentsuite/fxml/SCExportModal.java
@@ -171,7 +171,7 @@ public class SCExportModal extends VBox implements Cleanable, ImageCache {
                         Threads.awaitMillis(100);
                     }
 
-                    if (!exportProducer.isHardShutdown()) {
+                    if (exportProducer.isNotHardShutdown()) {
                         btnClose.fire();
                     }
                 }).start();

--- a/src/main/java/io/mattw/youtube/commentsuite/fxml/SCExportModal.java
+++ b/src/main/java/io/mattw/youtube/commentsuite/fxml/SCExportModal.java
@@ -97,8 +97,8 @@ public class SCExportModal extends VBox implements Cleanable, ImageCache {
             radioSeparate.setOnAction(ae -> updateExample());
             radioSingle.setOnAction(ae -> updateExample());
 
-            radioJSON.fire();
-            radioSeparate.fire();
+            radioCSV.fire();
+            radioSingle.fire();
 
             btnStop.setOnAction(ae -> {
                 shutdown = true;
@@ -363,5 +363,6 @@ public class SCExportModal extends VBox implements Cleanable, ImageCache {
         btnClose.setDisable(false);
 
         commentsProcessed = 0;
+        shutdown = false;
     }
 }

--- a/src/main/java/io/mattw/youtube/commentsuite/fxml/SCExportModal.java
+++ b/src/main/java/io/mattw/youtube/commentsuite/fxml/SCExportModal.java
@@ -248,11 +248,17 @@ public class SCExportModal extends VBox implements Cleanable, ImageCache {
             logger.debug("Writing file {}", videosFile.getName());
 
             if (format == JSON) {
+                for (YouTubeVideo video : videos) {
+                    video.prepForExport();
+                }
+
                 gson.toJson(videos, bw);
             } else {
                 printer.printRecord((Object[]) YouTubeVideo.CSV_HEADER);
 
                 for (YouTubeVideo video : videos) {
+                    video.prepForExport();
+
                     printer.printRecord(video.getCsvRow());
                 }
             }

--- a/src/main/java/io/mattw/youtube/commentsuite/fxml/SCExportModal.java
+++ b/src/main/java/io/mattw/youtube/commentsuite/fxml/SCExportModal.java
@@ -2,63 +2,70 @@ package io.mattw.youtube.commentsuite.fxml;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import com.google.gson.JsonParser;
+import com.google.gson.stream.JsonWriter;
 import io.mattw.youtube.commentsuite.CommentSuite;
 import io.mattw.youtube.commentsuite.ImageCache;
-import io.mattw.youtube.commentsuite.db.CommentDatabase;
-import io.mattw.youtube.commentsuite.db.CommentQuery;
+import io.mattw.youtube.commentsuite.db.*;
 import io.mattw.youtube.commentsuite.util.Threads;
 import javafx.fxml.FXML;
 import javafx.fxml.FXMLLoader;
 import javafx.scene.control.*;
+import javafx.scene.control.Button;
+import javafx.scene.control.Label;
+import javafx.scene.control.TextArea;
 import javafx.scene.layout.VBox;
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVPrinter;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.awt.*;
 import java.io.*;
 import java.nio.charset.StandardCharsets;
+import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.concurrent.atomic.AtomicLong;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Collection;
+import java.util.Set;
 
+import static io.mattw.youtube.commentsuite.fxml.ExportCommentFormat.*;
+import static io.mattw.youtube.commentsuite.fxml.ExportFormat.*;
 import static javafx.application.Platform.runLater;
 
 /**
  * This modal allows the full export of all comments in a query to the specified format
- * <p>
- * exports/
- * yyyy.MM.dd HH.mm.SS/
- * searchSettings.json
- * videoId1-meta.json
- * videoId1-comments.json
- * videoId2-meta.json
- * videoId2-comments.json
- * ...
  *
  * @see SearchComments
  */
 public class SCExportModal extends VBox implements Cleanable, ImageCache {
 
     private static final Logger logger = LogManager.getLogger();
+    private static final File EXPORT_FOLDER = new File("exports/");
+    private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd HH.mm.ss");
     private static final Gson gson = new GsonBuilder().setPrettyPrinting().create();
-    private static final String prettyFlattenedExample = gson.toJson(JsonParser.parseString(
-            "[{\"type\":\"comment\"},{\"type\":\"comment\"},{\"type\":\"reply\"},{\"type\":\"reply\"},{\"type\":\"comment\"}]"));
-    private static final String prettyCondensedExample = gson.toJson(JsonParser.parseString(
-            "[{\"type\":\"comment\"},{\"type\":\"comment\", replies:[{\"type\":\"reply\"},{\"type\":\"reply\"}]},{\"type\":\"comment\"}]"));
+    private static final String ls = System.getProperty("line.separator");
+    private static final String example =
+            "about.txt%1$s - Metadata about this export%1$s" +
+                    "videos.%2$s%1$s - %3$s of all videos%1$s - Affected by group(item) filters%1$s" +
+                    "comments%4$s.%2$s%1$s - %3$s of comments%1$s - Affected by comment filters%5$s";
+    private static final String exampleJsonSeparate = String.format(example, ls, "json", "Array", "-{videoId}", ls + " - Separate file per video");
+    private static final String exampleJsonSingle = String.format(example, ls, "json", "Array", "", ls + " - All in one file");
+    private static final String exampleCsvSeparate = String.format(example, ls, "csv", "List", "-{videoId}", ls + " - Separate file per video");
+    private static final String exampleCsvSingle = String.format(example, ls, "csv", "List", "", ls + " - All in one file");
+
 
     @FXML
     private Label errorMsg;
     @FXML
     private VBox exportPane;
     @FXML
-    private RadioButton radioCondensed, radioFlattened;
+    private RadioButton radioJSON, radioCSV, radioSeparate, radioSingle;
     @FXML
-    private TextArea exportModeExample;
+    private TextArea exportExample;
     @FXML
     private ProgressBar exportProgress;
-    @FXML
-    private ScrollPane helpScrollPane;
     @FXML
     private Button btnClose;
     @FXML
@@ -68,11 +75,9 @@ public class SCExportModal extends VBox implements Cleanable, ImageCache {
 
     private CommentQuery commentQuery;
     private CommentDatabase database;
-
-    private AtomicLong atomicVideoProgress = new AtomicLong(0);
-    private long totalVideos = 0;
-
     private SCExportProducer exportProducer;
+    private boolean shutdown = false;
+    private long commentsProcessed;
 
     public SCExportModal() {
         logger.debug("Initialize SCExportModal");
@@ -87,14 +92,16 @@ public class SCExportModal extends VBox implements Cleanable, ImageCache {
 
             cleanUp();
 
-            helpScrollPane.prefViewportHeightProperty().bind(exportPane.heightProperty());
+            radioJSON.setOnAction(ae -> updateExample());
+            radioCSV.setOnAction(ae -> updateExample());
+            radioSeparate.setOnAction(ae -> updateExample());
+            radioSingle.setOnAction(ae -> updateExample());
 
-            radioFlattened.setOnAction(ae -> runLater(() -> exportModeExample.setText(prettyFlattenedExample)));
-            radioCondensed.setOnAction(ae -> runLater(() -> exportModeExample.setText(prettyCondensedExample)));
-
-            radioFlattened.fire();
+            radioJSON.fire();
+            radioSeparate.fire();
 
             btnStop.setOnAction(ae -> {
+                shutdown = true;
                 exportProducer.setHardShutdown(true);
 
                 runLater(() -> btnStop.setDisable(true));
@@ -107,6 +114,18 @@ public class SCExportModal extends VBox implements Cleanable, ImageCache {
         }
     }
 
+    private void updateExample() {
+        runLater(() -> {
+            String exampleText;
+            if (radioJSON.isSelected()) {
+                exampleText = radioSeparate.isSelected() ? exampleJsonSeparate : exampleJsonSingle;
+            } else {
+                exampleText = radioSeparate.isSelected() ? exampleCsvSeparate : exampleCsvSingle;
+            }
+            exportExample.setText(exampleText);
+        });
+    }
+
     private void startExport() {
         runLater(() -> {
             btnSubmit.setVisible(false);
@@ -115,8 +134,10 @@ public class SCExportModal extends VBox implements Cleanable, ImageCache {
             exportProgress.setVisible(true);
             exportProgress.setManaged(true);
 
-            radioFlattened.setDisable(true);
-            radioCondensed.setDisable(true);
+            radioCSV.setDisable(true);
+            radioJSON.setDisable(true);
+            radioSeparate.setDisable(true);
+            radioSingle.setDisable(true);
 
             btnStop.setVisible(true);
             btnStop.setManaged(true);
@@ -127,28 +148,50 @@ public class SCExportModal extends VBox implements Cleanable, ImageCache {
         try {
             final CommentQuery duplicateQuery = commentQuery.duplicate();
 
-            exportProducer = new SCExportProducer(commentQuery, radioCondensed.isSelected());
-            createSearchSettingsFile(exportProducer.getThisExportFolder(), duplicateQuery);
+            final Set<YouTubeVideo> videos = duplicateQuery.getUniqueVideos();
+            final ExportFormat format = radioJSON.isSelected() ? JSON : CSV;
+            final ExportCommentFormat commentFormat = radioSeparate.isSelected() ? PER_VIDEO : SINGLE;
 
-            exportProducer.setMessageFunc(this::onMessage);
-            exportProducer.accept(duplicateQuery.getUniqueVideoIds());
-            exportProducer.startProducing();
+            final File exportFolder = new File(EXPORT_FOLDER, formatter.format(LocalDateTime.now()) + "/");
+            exportFolder.mkdirs();
 
-            new Thread(() -> {
-                while (exportProducer.shouldKeepAlive()) {
-                    updateProgress();
+            createAboutFile(exportFolder, duplicateQuery);
+            createVideosFile(exportFolder, videos, format);
 
-                    Threads.awaitMillis(100);
+            if (commentFormat == PER_VIDEO) {
+                exportProducer = new SCExportProducer(commentQuery, exportFolder, format);
+                exportProducer.setMessageFunc(this::onMessage);
+                exportProducer.accept(videos);
+                exportProducer.startProducing();
+
+                new Thread(() -> {
+                    while (exportProducer.shouldKeepAlive()) {
+                        updateProgressPerVideo();
+
+                        Threads.awaitMillis(100);
+                    }
+
+                    if (!exportProducer.isHardShutdown()) {
+                        btnClose.fire();
+                    }
+                }).start();
+
+                exportProducer.getExecutorGroup().await();
+                updateProgressPerVideo();
+                exportProducer.onCompletion();
+            } else {
+                createSingleCommentsFile(exportFolder, duplicateQuery, format);
+                updateProgressSingle();
+
+                try {
+                    logger.debug("Opening folder {}", exportFolder.getAbsolutePath());
+
+                    Desktop.getDesktop().open(exportFolder);
+                } catch (IOException e) {
+                    logger.warn("Failed to open export folder");
                 }
+            }
 
-                if (!exportProducer.isHardShutdown()) {
-                    btnClose.fire();
-                }
-            }).start();
-
-            exportProducer.getExecutorGroup().await();
-            updateProgress();
-            exportProducer.onCompletion();
         } catch (SQLException | InterruptedException e) {
             logger.error(e);
         } finally {
@@ -161,28 +204,115 @@ public class SCExportModal extends VBox implements Cleanable, ImageCache {
         }
     }
 
-    private void updateProgress() {
+    private void updateProgressPerVideo() {
         final double progress = exportProducer.getTotalProcessed().get() / (exportProducer.getTotalAccepted().get() * 1d);
         runLater(() -> exportProgress.setProgress(progress));
     }
 
-    private void createSearchSettingsFile(final File exportFolder, final CommentQuery query) {
-        final File searchSettings = new File(exportFolder, "searchSettings.json");
-        try (FileOutputStream fos = new FileOutputStream(searchSettings);
-             OutputStreamWriter writer = new OutputStreamWriter(fos, StandardCharsets.UTF_8);
-             BufferedWriter bw = new BufferedWriter(writer)) {
+    private void updateProgressSingle() {
+        final double progress = commentsProcessed / (commentQuery.getTotalResults() * 1d);
+        runLater(() -> exportProgress.setProgress(progress));
+    }
 
-            logger.debug("Writing file {}", searchSettings.getName());
+    private void createAboutFile(final File exportFolder, final CommentQuery query) {
+        final File aboutFile = new File(exportFolder, "about.txt");
+        try (final FileOutputStream fos = new FileOutputStream(aboutFile);
+             final OutputStreamWriter writer = new OutputStreamWriter(fos, StandardCharsets.UTF_8);
+             final BufferedWriter bw = new BufferedWriter(writer)) {
+
+            logger.debug("Writing file {}", aboutFile.getName());
 
             query.prepForExport();
+
+            bw.append("YouTube Comment Suite ").append(CommentSuite.getProperties().getProperty("version")).append(ls).append(ls);
+            bw.append("Export date: ").append(exportFolder.getName()).append(ls).append(ls);
+            bw.append("Search settings json:").append(ls);
 
             gson.toJson(query, bw);
 
             bw.flush();
         } catch (Exception e) {
-            logger.error("Failed to write json file(s)", e);
+            logger.error("Failed to write about file", e);
 
-            runLater(() -> setError("Failed to export."));
+            runLater(() -> setError("Problem during export"));
+        }
+    }
+
+    private void createVideosFile(final File exportFolder, final Collection<YouTubeVideo> videos, final ExportFormat format) {
+        final File videosFile = new File(exportFolder, "videos." + format.getExtension());
+        try (final FileOutputStream fos = new FileOutputStream(videosFile);
+             final OutputStreamWriter writer = new OutputStreamWriter(fos, StandardCharsets.UTF_8);
+             final BufferedWriter bw = new BufferedWriter(writer);
+             final CSVPrinter printer = new CSVPrinter(bw, CSVFormat.DEFAULT)) {
+
+            logger.debug("Writing file {}", videosFile.getName());
+
+            if (format == JSON) {
+                gson.toJson(videos, bw);
+            } else {
+                printer.printRecord((Object[]) YouTubeVideo.CSV_HEADER);
+
+                for (YouTubeVideo video : videos) {
+                    printer.printRecord(video.getCsvRow());
+                }
+            }
+
+            bw.flush();
+        } catch (Exception e) {
+            logger.error("Failed to write video file", e);
+
+            runLater(() -> setError("Problem during export"));
+        }
+    }
+
+    private void createSingleCommentsFile(final File exportFolder, final CommentQuery query, final ExportFormat format) {
+        final File videosFile = new File(exportFolder, "comments." + format.getExtension());
+
+        try (final FileOutputStream fos = new FileOutputStream(videosFile);
+             final OutputStreamWriter writer = new OutputStreamWriter(fos, StandardCharsets.UTF_8);
+             final BufferedWriter bw = new BufferedWriter(writer);
+             final CSVPrinter printer = new CSVPrinter(bw, CSVFormat.DEFAULT)) {
+            final JsonWriter jsonWriter = new JsonWriter(bw);
+            try {
+                logger.debug("Writing file {}", videosFile.getName());
+
+                if (format == CSV) {
+                    printer.printRecord((Object[]) YouTubeComment.CSV_HEADER);
+                }
+
+                try (final NamedParameterStatement namedParamStatement = query.toStatement()) {
+                    final ResultSet resultSet = namedParamStatement.executeQuery();
+
+                    while (resultSet.next() && !shutdown) {
+                        final YouTubeComment comment = database.comments().to(resultSet);
+                        comment.setAuthor(database.channels().getOrNull(comment.getChannelId()));
+                        comment.prepForExport();
+
+                        if (format == JSON) {
+                            gson.toJson(gson.toJsonTree(comment), jsonWriter);
+                        } else {
+                            printer.printRecord(comment.getCsvRow());
+                        }
+
+                        commentsProcessed++;
+
+                        final long total = query.getTotalResults();
+                        if (total < 25000 || commentsProcessed % 100 == 0) {
+                            updateProgressSingle();
+                        }
+                    }
+                }
+
+                bw.flush();
+            } finally {
+                if (format == JSON) {
+                    jsonWriter.close();
+                }
+            }
+        } catch (Exception e) {
+            logger.error("Failed to write comments file", e);
+
+            runLater(() -> setError("Problem during export"));
         }
     }
 
@@ -200,20 +330,6 @@ public class SCExportModal extends VBox implements Cleanable, ImageCache {
 
     public void withQuery(CommentQuery commentQuery) {
         this.commentQuery = commentQuery;
-
-        CommentQuery.CommentsType type = commentQuery.getCommentsType();
-
-        runLater(() -> {
-            boolean condensable = type == CommentQuery.CommentsType.ALL
-                    && StringUtils.isEmpty(commentQuery.getNameLike())
-                    && StringUtils.isEmpty(commentQuery.getTextLike());
-
-            radioCondensed.setDisable(!condensable);
-
-            if (!condensable) {
-                radioFlattened.fire();
-            }
-        });
     }
 
     public Button getBtnClose() {
@@ -236,12 +352,16 @@ public class SCExportModal extends VBox implements Cleanable, ImageCache {
         exportProgress.setManaged(false);
         exportProgress.setProgress(0.0);
 
-        radioFlattened.setDisable(false);
-        radioCondensed.setDisable(false);
+        radioCSV.setDisable(false);
+        radioJSON.setDisable(false);
+        radioSeparate.setDisable(false);
+        radioSingle.setDisable(false);
 
         btnStop.setVisible(false);
         btnStop.setManaged(false);
 
         btnClose.setDisable(false);
+
+        commentsProcessed = 0;
     }
 }

--- a/src/main/java/io/mattw/youtube/commentsuite/fxml/SCExportProducer.java
+++ b/src/main/java/io/mattw/youtube/commentsuite/fxml/SCExportProducer.java
@@ -91,7 +91,7 @@ public class SCExportProducer extends ConsumerMultiProducer<YouTubeVideo> {
                         .toStatement();
                      final ResultSet resultSet = namedParamStatement.executeQuery()) {
 
-                    while (resultSet.next() && !isHardShutdown()) {
+                    while (resultSet.next() && isNotHardShutdown()) {
                         hasComments = true;
 
                         final YouTubeComment comment = database.comments().to(resultSet);

--- a/src/main/java/io/mattw/youtube/commentsuite/fxml/SCExportProducer.java
+++ b/src/main/java/io/mattw/youtube/commentsuite/fxml/SCExportProducer.java
@@ -104,10 +104,12 @@ public class SCExportProducer extends ConsumerMultiProducer<String> {
         final File commentsFile = new File(thisExportFolder, String.format("%s-comments.json", video.getId()));
         final List<YouTubeVideo> videoList = Collections.singletonList(video);
 
-        if (condensedMode && commentQuery.getCommentsType() == CommentQuery.CommentsType.ALL) {
+        final CommentQuery duplicateQuery = commentQuery.duplicate();
+
+        if (condensedMode && duplicateQuery.getCommentsType() == CommentQuery.CommentsType.ALL) {
             // When condensed, we want base comments to be first.
             // We'll grab replies later if the replyCount > 0
-            commentQuery.setCommentsType(CommentQuery.CommentsType.COMMENTS_ONLY);
+            duplicateQuery.setCommentsType(CommentQuery.CommentsType.COMMENTS_ONLY);
         }
 
         try (final FileOutputStream fos = new FileOutputStream(commentsFile);
@@ -117,7 +119,7 @@ public class SCExportProducer extends ConsumerMultiProducer<String> {
 
             jsonWriter.beginArray();
 
-            try (final NamedParameterStatement namedParamStatement = commentQuery
+            try (final NamedParameterStatement namedParamStatement = duplicateQuery
                     .setVideos(Optional.of(videoList))
                     .toStatement();
                  final ResultSet resultSet = namedParamStatement.executeQuery()) {

--- a/src/main/java/io/mattw/youtube/commentsuite/fxml/SYAddToGroupModal.java
+++ b/src/main/java/io/mattw/youtube/commentsuite/fxml/SYAddToGroupModal.java
@@ -19,7 +19,6 @@ import org.apache.logging.log4j.Logger;
 import java.io.IOException;
 import java.sql.SQLException;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 

--- a/src/main/java/io/mattw/youtube/commentsuite/fxml/SearchComments.java
+++ b/src/main/java/io/mattw/youtube/commentsuite/fxml/SearchComments.java
@@ -352,7 +352,6 @@ public class SearchComments implements Initializable, ImageCache {
 
         SCExportModal scExportModal = new SCExportModal();
         exportModal.setContent(scExportModal);
-        exportModal.getModalContainer().setMaxWidth(exportModal.getModalContainer().getMaxWidth() * 1.5);
         scExportModal.getBtnClose().setOnAction(ae -> exportModal.setVisible(false));
         btnExport.setOnAction(ae -> {
             scExportModal.cleanUp();

--- a/src/main/java/io/mattw/youtube/commentsuite/fxml/SearchYouTube.java
+++ b/src/main/java/io/mattw/youtube/commentsuite/fxml/SearchYouTube.java
@@ -8,7 +8,6 @@ import io.mattw.youtube.commentsuite.ImageLoader;
 import io.mattw.youtube.commentsuite.util.BrowserUtil;
 import io.mattw.youtube.commentsuite.util.ClipboardUtil;
 import io.mattw.youtube.commentsuite.util.IpApiProvider;
-import io.mattw.youtube.commentsuite.util.Location;
 import javafx.beans.binding.BooleanBinding;
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.collections.ListChangeListener;

--- a/src/main/java/io/mattw/youtube/commentsuite/fxml/SearchYouTubeListItem.java
+++ b/src/main/java/io/mattw/youtube/commentsuite/fxml/SearchYouTubeListItem.java
@@ -47,43 +47,49 @@ public class SearchYouTubeListItem extends HBox {
         loader.setRoot(this);
         loader.load();
 
-        number.setText(String.format("# %s", num));
-        thumbnail.setFitWidth(thumbnail.getFitHeight() * loading.getWidth() / loading.getHeight());
-        thumbnail.setImage(loading);
+        runLater(() -> {
+            number.setText(String.format("# %s", num));
+            thumbnail.setFitWidth(thumbnail.getFitHeight() * loading.getWidth() / loading.getHeight());
+            thumbnail.setImage(loading);
 
-        if ((objectId = data.getId().getVideoId()) != null) {
-            youtubeURL = String.format("https://youtu.be/%s", objectId);
-            typeStr = "Video";
-        } else if ((objectId = data.getId().getChannelId()) != null) {
-            youtubeURL = String.format("https://www.youtube.com/channel/%s", objectId);
-            typeStr = "Channel";
-        } else if ((objectId = data.getId().getPlaylistId()) != null) {
-            youtubeURL = String.format("https://www.youtube.com/playlist?list=%s", objectId);
-            typeStr = "Playlist";
-        } else {
-            logger.error("A SearchList.Item object has been passed with no id.");
-            typeStr = "Error";
-        }
+            if ((objectId = data.getId().getVideoId()) != null) {
+                youtubeURL = String.format("https://youtu.be/%s", objectId);
+                typeStr = "Video";
+            } else if ((objectId = data.getId().getChannelId()) != null) {
+                youtubeURL = String.format("https://www.youtube.com/channel/%s", objectId);
+                typeStr = "Channel";
+            } else if ((objectId = data.getId().getPlaylistId()) != null) {
+                youtubeURL = String.format("https://www.youtube.com/playlist?list=%s", objectId);
+                typeStr = "Playlist";
+            } else {
+                logger.error("A SearchList.Item object has been passed with no id.");
+                typeStr = "Error";
+            }
 
-        type.setText(typeStr);
+            type.setText(typeStr);
+        });
 
         if (data.getSnippet() != null) {
-            title.setText(data.getSnippet().getTitle());
-            author.setText(data.getSnippet().getChannelTitle());
-            description.setText(data.getSnippet().getDescription());
+            runLater(() -> {
+                title.setText(data.getSnippet().getTitle());
+                author.setText(data.getSnippet().getChannelTitle());
+                description.setText(data.getSnippet().getDescription());
+            });
 
             new Thread(() -> {
                 final YouTubeSearchItem searchItem = new YouTubeSearchItem(data);
                 final Image thumb = searchItem.findOrGetThumb();
-                thumbnail.setFitWidth(thumbnail.getFitHeight() * thumb.getWidth() / thumb.getHeight());
-                thumbnail.setImage(thumb);
+                runLater(() -> {
+                    thumbnail.setFitWidth(thumbnail.getFitHeight() * thumb.getWidth() / thumb.getHeight());
+                    thumbnail.setImage(thumb);
+                });
             }).start();
         } else {
-            title.setText("SearchList.Item Error");
-            author.setText(data.getEtag());
-            description.setText("There was no snippet attached to this object.");
             final Image thumb = ImageLoader.OOPS.getImage();
             runLater(() -> {
+                title.setText("SearchList.Item Error");
+                author.setText(data.getEtag());
+                description.setText("There was no snippet attached to this object.");
                 thumbnail.setFitWidth(thumbnail.getFitHeight() * thumb.getWidth() / thumb.getHeight());
                 thumbnail.setImage(thumb);
             });

--- a/src/main/java/io/mattw/youtube/commentsuite/fxml/SearchYouTubeListItem.java
+++ b/src/main/java/io/mattw/youtube/commentsuite/fxml/SearchYouTubeListItem.java
@@ -1,7 +1,6 @@
 package io.mattw.youtube.commentsuite.fxml;
 
 import com.google.api.services.youtube.model.SearchResult;
-import io.mattw.youtube.commentsuite.ImageCache;
 import io.mattw.youtube.commentsuite.ImageLoader;
 import javafx.fxml.FXML;
 import javafx.fxml.FXMLLoader;

--- a/src/main/java/io/mattw/youtube/commentsuite/refresh/CommentThreadProducer.java
+++ b/src/main/java/io/mattw/youtube/commentsuite/refresh/CommentThreadProducer.java
@@ -246,7 +246,7 @@ public class CommentThreadProducer extends ConsumerMultiProducer<YouTubeVideo> {
                         }
 
                         awaitMillis(50);
-                    } while (pageToken != null && page++ < pages.getPageCount() && !isHardShutdown());
+                    } while (pageToken != null && page++ < pages.getPageCount() && isNotHardShutdown());
 
                     logger.info("{} Completed {} {}", moderationStatus, video.getId(), video.getTitle());
 
@@ -333,7 +333,7 @@ public class CommentThreadProducer extends ConsumerMultiProducer<YouTubeVideo> {
                         attempt++;
                     }
                 }
-            } while (attempt <= maxAttempts && !isHardShutdown());
+            } while (attempt <= maxAttempts && isNotHardShutdown());
 
             addProcessed(1);
             awaitMillis(500);

--- a/src/main/java/io/mattw/youtube/commentsuite/refresh/ConsumerMultiProducer.java
+++ b/src/main/java/io/mattw/youtube/commentsuite/refresh/ConsumerMultiProducer.java
@@ -132,8 +132,8 @@ public abstract class ConsumerMultiProducer<C> {
         this.hardShutdown = hardShutdown;
     }
 
-    public boolean isHardShutdown() {
-        return hardShutdown;
+    public boolean isNotHardShutdown() {
+        return !hardShutdown;
     }
 
     /**

--- a/src/main/java/io/mattw/youtube/commentsuite/refresh/ConsumerMultiProducer.java
+++ b/src/main/java/io/mattw/youtube/commentsuite/refresh/ConsumerMultiProducer.java
@@ -3,7 +3,6 @@ package io.mattw.youtube.commentsuite.refresh;
 import com.google.api.client.googleapis.json.GoogleJsonError;
 import com.google.api.client.googleapis.json.GoogleJsonResponseException;
 import io.mattw.youtube.commentsuite.util.ExecutorGroup;
-import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;

--- a/src/main/java/io/mattw/youtube/commentsuite/refresh/GroupRefresh.java
+++ b/src/main/java/io/mattw/youtube/commentsuite/refresh/GroupRefresh.java
@@ -232,15 +232,12 @@ public class GroupRefresh extends Thread implements RefreshInterface {
             final GoogleJsonResponseException googleError = (GoogleJsonResponseException) error;
             final String reasonCode = ConsumerMultiProducer.getFirstReasonCode(googleError);
 
-            switch (reasonCode) {
-                case "quotaExceeded":
-                    endedOnError = true;
-                    hardShutdown();
-                    runLater(() -> errorList.add(0, String.format("%s - %s", time, googleError)));
-                    break;
-
-                default:
-                    logger.warn(googleError);
+            if ("quotaExceeded".equals(reasonCode)) {
+                endedOnError = true;
+                hardShutdown();
+                runLater(() -> errorList.add(0, String.format("%s - %s", time, googleError)));
+            } else {
+                logger.warn(googleError);
             }
         }
 

--- a/src/main/java/io/mattw/youtube/commentsuite/refresh/ReplyProducer.java
+++ b/src/main/java/io/mattw/youtube/commentsuite/refresh/ReplyProducer.java
@@ -8,7 +8,6 @@ import io.mattw.youtube.commentsuite.db.YouTubeChannel;
 import io.mattw.youtube.commentsuite.db.YouTubeComment;
 import io.mattw.youtube.commentsuite.util.ExecutorGroup;
 import io.mattw.youtube.commentsuite.util.StringTuple;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/src/main/java/io/mattw/youtube/commentsuite/refresh/ReplyProducer.java
+++ b/src/main/java/io/mattw/youtube/commentsuite/refresh/ReplyProducer.java
@@ -89,7 +89,7 @@ public class ReplyProducer extends ConsumerMultiProducer<StringTuple> {
                     sendCollection(channels, YouTubeChannel.class);
 
                     awaitMillis(50);
-                } while (pageToken != null && page++ < replyPages.getPageCount() && !isHardShutdown());
+                } while (pageToken != null && page++ < replyPages.getPageCount() && isNotHardShutdown());
             } catch (IOException e) {
                 sendMessage(Level.ERROR, e, String.format("Couldn't grab commentThread[id=%s]", tuple.getFirst()));
             }

--- a/src/main/java/io/mattw/youtube/commentsuite/util/FXUtils.java
+++ b/src/main/java/io/mattw/youtube/commentsuite/util/FXUtils.java
@@ -27,7 +27,7 @@ public class FXUtils {
     }
 
     /**
-     * Modifies a TextField's preferred width based on it's text content
+     * Modifies a TextField's preferred width based on its text content
      *
      * @param field TextField element
      * @link https://stackoverflow.com/a/25643696/2650847

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+version=${version}
+current.year=${current.year}

--- a/src/main/resources/io/mattw/youtube/commentsuite/fxml/SCExportModal.fxml
+++ b/src/main/resources/io/mattw/youtube/commentsuite/fxml/SCExportModal.fxml
@@ -1,85 +1,44 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?import javafx.scene.control.Button?>
-<?import javafx.scene.layout.HBox?>
-<?import javafx.scene.layout.VBox?>
-<?import javafx.scene.control.Label?>
-<?import javafx.scene.control.TextArea?>
-<?import javafx.scene.control.RadioButton?>
-<?import javafx.scene.control.ToggleGroup?>
-<?import javafx.scene.control.TabPane?>
-<?import javafx.scene.control.Tab?>
 <?import javafx.geometry.Insets?>
-<?import javafx.scene.control.ScrollPane?>
-<?import javafx.scene.control.ProgressBar?>
+<?import javafx.scene.control.*?>
+<?import javafx.scene.layout.*?>
 <fx:root type="VBox"
          xmlns="http://javafx.com/javafx"
          xmlns:fx="http://javafx.com/fxml"
          spacing="10">
     <fx:define>
-        <ToggleGroup fx:id="toggleGroup" />
+        <ToggleGroup fx:id="toggleGroup"/>
+        <ToggleGroup fx:id="toggleGroup2"/>
     </fx:define>
-    <TabPane>
-        <Tab text="Export" closable="false">
-            <VBox fx:id="exportPane" spacing="5">
-                <padding>
-                    <Insets top="10" />
-                </padding>
-                <fx:include fx:id="errorMsg" source="AlertLabel.fxml" styleClass="alertWarning" alignment="CENTER"
-                            VBox.vgrow="ALWAYS"
-                            text="Warning: Condensed mode may take a very long time."/>
-                <ProgressBar fx:id="exportProgress" visible="false" managed="false" maxWidth="Infinity" VBox.vgrow="ALWAYS" />
-                <HBox spacing="10">
-                    <VBox spacing="10" minWidth="120">
-                        <Label text="Export mode:" styleClass="bold"/>
-                        <RadioButton fx:id="radioFlattened" text="Flattened" toggleGroup="$toggleGroup"/>
-                        <RadioButton fx:id="radioCondensed" text="Condensed" toggleGroup="$toggleGroup"/>
-                    </VBox>
-                    <VBox spacing="10">
-                        <Label text="Example:" styleClass="bold"/>
-                        <TextArea fx:id="exportModeExample" editable="false" styleClass="font14"
-                                  style="-fx-font-family: 'monospaced';"
-                                  prefColumnCount="60"/>
-                    </VBox>
-                </HBox>
+    <VBox fx:id="exportPane" spacing="5">
+        <padding>
+            <Insets top="10"/>
+        </padding>
+        <fx:include fx:id="errorMsg" source="AlertLabel.fxml" styleClass="alertWarning" alignment="CENTER"
+                    VBox.vgrow="ALWAYS" text=""/>
+        <ProgressBar fx:id="exportProgress" visible="false" managed="false" maxWidth="Infinity" VBox.vgrow="ALWAYS"/>
+        <HBox spacing="10">
+            <VBox spacing="10" minWidth="150">
+                <Label text="Export format" styleClass="bold"/>
+                <RadioButton fx:id="radioJSON" text="JSON" toggleGroup="$toggleGroup"/>
+                <RadioButton fx:id="radioCSV" text="CSV" toggleGroup="$toggleGroup"/>
+                <Label />
+                <Label text="Export comments" styleClass="bold"/>
+                <RadioButton fx:id="radioSeparate" text="File per video" toggleGroup="$toggleGroup2"/>
+                <RadioButton fx:id="radioSingle" text="Single file" toggleGroup="$toggleGroup2"/>
             </VBox>
-        </Tab>
-        <Tab text="Help" closable="false">
-            <ScrollPane fx:id="helpScrollPane" fitToHeight="true" fitToWidth="true" hbarPolicy="NEVER" maxHeight="230" styleClass="noBorder">
-                <VBox spacing="10">
-                    <padding>
-                        <Insets top="10" />
-                    </padding>
-                    <Label styleClass="font18" text="How it works"/>
-
-                    <Label wrapText="true" styleClass="font14"
-                           text="The export function allows you to save your search results in a more readily&#13;usable format, JSON."/>
-
-                    <Label wrapText="true" styleClass="font14"
-                           text=" — Current search settings are saved to file searchSettings.json"/>
-                    <Label wrapText="true" styleClass="font14"
-                           text=" — Video information is saved to files in format {videoId}-meta.json"/>
-                    <Label wrapText="true" styleClass="font14"
-                           text=" — Comments and replies are are saved to files in format {videoId}-comments.json"/>
-                    <Label wrapText="true" styleClass="font14"
-                           text=" — Everything is saved under folder named with the current date and time."/>
-
-                    <Label wrapText="true" styleClass="font14"
-                           text="Flattened mode exports comments and replies in the same way that it is shown&#13;in the Search Comments list."/>
-
-                    <Label wrapText="true" styleClass="font14"
-                           text="Condensed mode exports comments and replies with comments at base level and&#13;replies under them. It is also only available to be used when &#13;using &quot;Comments and Replies&quot; with no name and text filters."/>
-
-                    <Label wrapText="true" styleClass="font14"
-                           text="Condensed mode will also take longer as it has to grab replies for each thread."/>
-
-                </VBox>
-            </ScrollPane>
-        </Tab>
-    </TabPane>
+            <VBox spacing="10">
+                <Label text="Export structure" styleClass="bold"/>
+                <TextArea fx:id="exportExample" editable="false" styleClass="font14"
+                          style="-fx-font-family: 'monospaced';"
+                          prefColumnCount="60"/>
+            </VBox>
+        </HBox>
+    </VBox>
     <HBox spacing="10" alignment="CENTER_RIGHT">
-        <Button fx:id="btnClose" styleClass="btnLight" text="Close" />
-        <Button fx:id="btnStop" styleClass="btnDanger" text="Stop" visible="false" managed="false" />
-        <Button fx:id="btnSubmit" styleClass="btnPrimary" text="Export to JSON" />
+        <Button fx:id="btnClose" styleClass="btnLight" text="Close"/>
+        <Button fx:id="btnStop" styleClass="btnDanger" text="Stop" visible="false" managed="false"/>
+        <Button fx:id="btnSubmit" styleClass="btnPrimary" text="Export"/>
     </HBox>
 </fx:root>

--- a/src/main/resources/io/mattw/youtube/commentsuite/fxml/SCExportModal.fxml
+++ b/src/main/resources/io/mattw/youtube/commentsuite/fxml/SCExportModal.fxml
@@ -21,12 +21,12 @@
         <HBox spacing="10">
             <VBox spacing="10" minWidth="150">
                 <Label text="Export format" styleClass="bold"/>
-                <RadioButton fx:id="radioJSON" text="JSON" toggleGroup="$toggleGroup"/>
                 <RadioButton fx:id="radioCSV" text="CSV" toggleGroup="$toggleGroup"/>
+                <RadioButton fx:id="radioJSON" text="JSON" toggleGroup="$toggleGroup"/>
                 <Label />
                 <Label text="Export comments" styleClass="bold"/>
-                <RadioButton fx:id="radioSeparate" text="File per video" toggleGroup="$toggleGroup2"/>
                 <RadioButton fx:id="radioSingle" text="Single file" toggleGroup="$toggleGroup2"/>
+                <RadioButton fx:id="radioSeparate" text="File per video" toggleGroup="$toggleGroup2"/>
             </VBox>
             <VBox spacing="10">
                 <Label text="Export structure" styleClass="bold"/>


### PR DESCRIPTION
- Revamp the comment export functionality #35 #75 #83 
    - Fix issue with duplicate and missing comments #84 
    - Export to CSV or JSON
    - Export comments as a single-file or file-per-video
    - Default option is now CSV single-file
    - searchSettings.json is now about.txt
    - Video details are always single-file now and not file-per-video
- Search YouTube section now handles when you reach the last available page of results #85 